### PR TITLE
[index.slim] Override height from guide's styles

### DIFF
--- a/app/views/index.slim
+++ b/app/views/index.slim
@@ -27,7 +27,7 @@ html
       }
 
       h2 {
-        margin: 128px 0 32px;
+        margin: 40x 0 32px;
         text-align: center;
       }
 
@@ -107,6 +107,9 @@ html
           position:relative;
           margin-bottom: 16px;
         }
+      }
+      .headline {
+        height: auto;
       }
 
 


### PR DESCRIPTION
Fixes issue with mobile layout

![screen shot 2015-05-31 at 21 44 21](https://cloud.githubusercontent.com/assets/1333960/7903489/44b8947e-07de-11e5-94ff-9f8ac9ab08b7.png)
